### PR TITLE
Remove ability to reopen channels

### DIFF
--- a/lib/goru/channel.rb
+++ b/lib/goru/channel.rb
@@ -64,13 +64,6 @@ module Goru
 
     # [public]
     #
-    def reopen
-      @closed = false
-      @observers.each(&:channel_reopened)
-    end
-
-    # [public]
-    #
     def clear
       @messages.clear
     end

--- a/lib/goru/routines/bridge.rb
+++ b/lib/goru/routines/bridge.rb
@@ -41,10 +41,6 @@ module Goru
       def channel_closed
         update_status
       end
-
-      def channel_reopened
-        update_status
-      end
     end
   end
 end

--- a/lib/goru/routines/channel.rb
+++ b/lib/goru/routines/channel.rb
@@ -36,10 +36,6 @@ module Goru
       def channel_closed
         update_status
       end
-
-      def channel_reopened
-        update_status
-      end
     end
   end
 end


### PR DESCRIPTION
In practice this proves to be confusing—better to create a new channel.