### PR TITLE
Finish routines on error

### DIFF
--- a/lib/goru/routine.rb
+++ b/lib/goru/routine.rb
@@ -100,7 +100,7 @@ module Goru
     #
     private def status_changed
       case @status
-      when :finished
+      when :errored, :finished
         @reactor&.routine_finished(self)
       end
     end


### PR DESCRIPTION
Otherwise errored routines will appear to run forever, even though they are finished.