### PR TITLE
Cleanup finished routines on next tick

### DIFF
--- a/lib/goru/routines/io.rb
+++ b/lib/goru/routines/io.rb
@@ -23,7 +23,7 @@ module Goru
       #
       attr_reader :io, :intent
 
-      attr_writer :monitor
+      attr_accessor :monitor
 
       # [public]
       #


### PR DESCRIPTION
Letting the reactor cleanup after itself avoids edge-cases with deregistering a monitor.